### PR TITLE
Packages cleanup, convert boot script to systemd service, pass a few OVAL definitions.

### DIFF
--- a/config/hardening/hardened-centos.cfg
+++ b/config/hardening/hardened-centos.cfg
@@ -37,42 +37,21 @@ timezone --utc America/New_York
 %packages
 # MINIMUM
 @core
-dracut-fips
 fipscheck
-logwatch
-scrub
-aide
 vlock
-screen
 chrony
-libreswan
 rsyslog
 gnupg2
-yum-utils
-tpm-tools
 trousers
 which
-unzip
-bzip2
-zip
-# SmartCard
-pam_pkcs11
-pcsc-lite
-ccid
-coolkey
 # SCAP CONTENT
 openscap
-openscap-utils
 xml-common
 # OPTIONAL
 openssh-clients
 cryptsetup-luks
 krb5-libs
-krb5-workstation
-pam_krb5
 virt-what
-dos2unix
-unix2dos
 xz
 # REMOVE PACKAGES
 -abrt*
@@ -190,9 +169,6 @@ ssh-keygen -b 521 -t ecdsa -N "" -f /etc/ssh/ssh_host_ecdsa_key
 # Clean Up
 rm -rf /root/hardening
 
-# rc.local
-chmod +x /etc/rc.local
-
 cat << EOF >> /root/clean_up.sh
 #!/bin/bash
 ########################################
@@ -211,14 +187,51 @@ exit 0
 EOF
 chmod 500 /root/clean_up.sh
 echo "/root/clean_up.sh" >> /etc/rc.local
-cat << EOF >> /etc/rc.local
-########################################
+
+#######################################
 # Disable Radios (wifi, wimax, wwwan)
 # NIST 800-53: SC-40, AC-18
-########################################
-nmcli radio all off
+#######################################
+touch /etc/systemd/system/disablewifi.service
+cat << EOF >> /etc/systemd/system/disablewifi.service
+[Unit]
+Description=Disable Radios (wifi, wimax, wwwan) NIST 800-53: SC-40, AC-18
+After=NetworkManager.service
+Requires=NetworkManager.service
 
+[Service]
+ExecStart=/bin/sh -c 'nmcli radio all off'
+
+[Install]
+WantedBy=multi-user.target
 EOF
+systemctl enable disablewifi
+
+######################################
+# Install packages manually
+######################################
+
+yum install -y pcsc-lite
+yum install -y pam_pkcs11
+yum install -y tpm-tools
+yum install -y pam_krb5
+yum install -y scrub
+yum install -y krb5-workstation
+yum install -y yum-utils
+yum install -y libreswan
+yum install -y coolkey
+yum install -y logwatch
+yum install -y dracut-fips
+yum install -y vsftpd
+yum install -y ntp
+
+systemctl enable ntpd
+
+###################################
+# Remove packages manually
+##################################
+yum remove -y openssh-server
+yum remove -y kexec-tools
 
 # Clean Yum
 yum clean all &> /dev/null


### PR DESCRIPTION
1) Several packages were not being installed even though they were defined within the packages segment.
    Moved those packages to post install segment to be manually installed.
2) Several packages were not found (ccid, unix2dos, dos2unix). Removed.
3) Some packages were stating they were not found in the package segment, but were installed anyhow (e.g. aide).
4) Converted boot script that disables wifi to a systemd service to avoid tampering with permissions on `/etc/rc.local` (causes oval def oval:ssg-rpm_verify_permissions:def:1 to fail)
5) Added vsftpd, ntp to pass ovals [oval:ssg-package_vsftpd_installed:def:1, oval:ssg-package_ntp_installed:def:1]
6) Removed openssh-server, kexec-tools to pass ovals [oval:ssg-package_openssh-server_removed:def:1, oval:ssg-package_kexec-tools_removed:def:1]
