### PR TITLE
Various small fixes/updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.iso
+hardened-tmp/
+original-mnt/

--- a/config/hardening/menu.py
+++ b/config/hardening/menu.py
@@ -1053,17 +1053,17 @@ class Display_Menu:
 			f.write('volgroup vg1 --pesize=4096 pv.01\n')
 			if os.path.isdir('/sys/firmware/efi'):
 				f.write('part /boot/efi --fstype=efi --size=200\n')
-			f.write('logvol / --fstype=xfs --name=lv_root --vgname=vg1 --grow --percent='+str(self.root_partition.get_value_as_int())+'\n')
-			f.write('logvol /home --fstype=xfs --name=lv_home --vgname=vg1 --grow --percent='+str(self.home_partition.get_value_as_int())+'\n')
-			f.write('logvol /tmp --fstype=xfs --name=lv_tmp --vgname=vg1 --grow --percent='+str(self.tmp_partition.get_value_as_int())+'\n')
-			f.write('logvol /var --fstype=xfs --name=lv_var --vgname=vg1 --grow --percent='+str(self.var_partition.get_value_as_int())+'\n')
-			f.write('logvol /var/log --fstype=xfs --name=lv_log --vgname=vg1 --grow --percent='+str(self.log_partition.get_value_as_int())+'\n')
-			f.write('logvol /var/log/audit --fstype=xfs --name=lv_audit --vgname=vg1 --grow --percent='+str(self.audit_partition.get_value_as_int())+'\n')
-			f.write('logvol swap --fstype=swap --name=lv_swap --vgname=vg1 --maxsize=4096 --grow --percent='+str(self.swap_partition.get_value_as_int())+'\n')
+			f.write('logvol / --fstype=xfs --name=lv_root --vgname=vg1 --percent='+str(self.root_partition.get_value_as_int())+'\n')
+			f.write('logvol /home --fstype=xfs --name=lv_home --vgname=vg1 --percent='+str(self.home_partition.get_value_as_int())+'\n')
+			f.write('logvol /tmp --fstype=xfs --name=lv_tmp --vgname=vg1 --percent='+str(self.tmp_partition.get_value_as_int())+'\n')
+			f.write('logvol /var --fstype=xfs --name=lv_var --vgname=vg1 --percent='+str(self.var_partition.get_value_as_int())+'\n')
+			f.write('logvol /var/log --fstype=xfs --name=lv_log --vgname=vg1 --percent='+str(self.log_partition.get_value_as_int())+'\n')
+			f.write('logvol /var/log/audit --fstype=xfs --name=lv_audit --vgname=vg1 --percent='+str(self.audit_partition.get_value_as_int())+'\n')
+			f.write('logvol swap --fstype=swap --name=lv_swap --vgname=vg1 --maxsize=4096 --percent='+str(self.swap_partition.get_value_as_int())+'\n')
 			if self.opt_partition.get_value_as_int() >= 1:
-				f.write('logvol /opt --fstype=xfs --name=lv_opt --vgname=vg1 --grow --percent='+str(self.opt_partition.get_value_as_int())+'\n')
+				f.write('logvol /opt --fstype=xfs --name=lv_opt --vgname=vg1 --percent='+str(self.opt_partition.get_value_as_int())+'\n')
 			if self.www_partition.get_value_as_int() >= 1:
-				f.write('logvol /var/www --fstype=xfs --name=lv_www --vgname=vg1 --grow --percent='+str(self.www_partition.get_value_as_int())+'\n')
+				f.write('logvol /var/www --fstype=xfs --name=lv_www --vgname=vg1 --percent='+str(self.www_partition.get_value_as_int())+'\n')
 			f.close()
 			gtk.main_quit()
 

--- a/config/hardening/menu.py
+++ b/config/hardening/menu.py
@@ -284,6 +284,10 @@ class Display_Menu:
 		self.nousb_kernel.set_active(False)
 		self.encrypt.pack_start(self.nousb_kernel, False, True, 0)
 
+		self.lock_root = gtk.CheckButton('Lock root')
+		self.lock_root.set_active(True)
+		self.encrypt.pack_start(self.lock_root, False, True, 0)
+
 		self.vbox.add(self.encrypt)
 
 		# By default, do not disable USB support if a USB keyboard is present
@@ -969,7 +973,7 @@ class Display_Menu:
 					self.MessageBox(self.window,"<b>Password too short! 15 Characters Required.</b>",gtk.MESSAGE_ERROR)
 			else:
 				self.MessageBox(self.window,"<b>Passwords Don't Match!</b>",gtk.MESSAGE_ERROR)
-			
+
                 self.error = 0
 
 		if self.verify.check_hostname(self.hostname.get_text()) == False:
@@ -1040,7 +1044,7 @@ class Display_Menu:
 			# Write Kickstart Configuration
 			f = open('/tmp/hardening','w')
 			f.write('network --hostname '+self.hostname.get_text()+' \n')
-			f.write('rootpw --iscrypted '+str(self.password)+' --lock\n')
+			f.write('rootpw --iscrypted '+str(self.password)+(' --lock' if self.lock_root.get_active() == True else '')+'\n')
                         f.write('bootloader --location=mbr --driveorder='+str(self.data["INSTALL_DRIVES"])+' --append="crashkernel=auto rhgb quiet audit=1" --password='+self.quoted_password+'\n')
 			f.write('user --name=admin --groups=wheel --password='+str(self.password)+' --iscrypted \n')
 			f.close()

--- a/config/hardening/menu.py
+++ b/config/hardening/menu.py
@@ -1004,6 +1004,9 @@ class Display_Menu:
 			self.salt = '$6$'+self.salt
 			self.password = crypt.crypt(self.passwd,self.salt)
 
+                        # Quote Password
+                        self.quoted_password = '"%s"' % self.passwd.replace('\\','\\\\').replace('"','\\"')
+
 			# Write Classification Banner Settings
 			f = open('/tmp/classification-banner','w')
 			f.write('message = "'+str(self.system_classification.get_active_text())+'"\n')
@@ -1034,7 +1037,7 @@ class Display_Menu:
 			f = open('/tmp/hardening','w')
 			f.write('network --hostname '+self.hostname.get_text()+' \n')
 			f.write('rootpw --iscrypted '+str(self.password)+' --lock\n')
-                        f.write('bootloader --location=mbr --driveorder='+str(self.data["INSTALL_DRIVES"])+' --append="crashkernel=auto rhgb quiet audit=1" --password='+str(self.a)+'\n')
+                        f.write('bootloader --location=mbr --driveorder='+str(self.data["INSTALL_DRIVES"])+' --append="crashkernel=auto rhgb quiet audit=1" --password='+self.quoted_password+'\n')
 			f.write('user --name=admin --groups=wheel --password='+str(self.password)+' --iscrypted \n')
 			f.close()
 			f = open('/tmp/partitioning','w')
@@ -1043,7 +1046,7 @@ class Display_Menu:
 			f.write('zerombr\n')
 			f.write('clearpart --all --drives='+str(self.data["INSTALL_DRIVES"])+'\n')
 			if self.encrypt_disk.get_active() == True:
-				f.write('part pv.01 --grow --size=200 --encrypted --cipher=\'aes-xts-plain64\' --passphrase='+str(self.passwd)+'\n')
+				f.write('part pv.01 --grow --size=200 --encrypted --cipher=\'aes-xts-plain64\' --passphrase='+self.quoted_password+'\n')
 			else:
 				f.write('part pv.01 --grow --size=200\n')
 			f.write('part /boot --fstype=xfs --size=1024\n')

--- a/config/hardening/menu.py
+++ b/config/hardening/menu.py
@@ -8,7 +8,7 @@
 # Copyright: Frank Caviggia, (C) 2016
 # License: GPLv2
 
-import os,sys,re,crypt,random
+import os,sys,re,crypt,random,pyudev
 try:
 	os.environ['DISPLAY']
 	import pygtk,gtk
@@ -280,13 +280,17 @@ class Display_Menu:
 		self.fips_kernel.set_active(True)
 		self.encrypt.pack_start(self.fips_kernel, False, True, 0)
 
-                
 		self.nousb_kernel = gtk.CheckButton('Disable USB (nousb)')
 		self.nousb_kernel.set_active(False)
 		self.encrypt.pack_start(self.nousb_kernel, False, True, 0)
 
 		self.vbox.add(self.encrypt)
 
+		# By default, do not disable USB support if a USB keyboard is present
+		if any([device.parent.device_type==u'usb_interface' for device in pyudev.Context().list_devices(subsystem='input') if device.get('ID_INPUT_KEYBOARD', None)]):
+			self.nousb_kernel.set_active(False)
+		else:
+			self.nousb_kernel.set_active(True)
 
 		# Minimal Installation Warning
 		if self.disk_total < 8:


### PR DESCRIPTION
Feel free to cherry-pick just the ones you like (or I could do 5 separate pull requests):

1. Git ignore the temp dirs and output iso.
  a. This was missed in my earlier pull request.
2. Handle spaces and quotes in LUKS (and grub) passphrase.
3. RHEL7 considers percent on logvol to be minimum size if used with grow.
  a. On EL6, logvol --grow --percent treated the percentage as a maximum size.  But, on EL7, it treats it as a minimum size and will consume the entire volume group.
4. Disable USB by default unless a USB keyboard is attached.
  a. This commit attempts to query udev for the presence of any attached USB keyboards.  If any are detected, "nousb" will be disabled by default.
5. Add option to unlock root account for single-user sulogin.
  a. If the root account is locked in kickstart, the root password cannot be used at the sulogin prompt to get into single-user maintenance mode.  This commit adds a check-box to configure this; the default state is locked.
