### PR TITLE
Auto generating the USB Guard rules file on installation.

### DIFF
--- a/config/hardening/hardened-centos.cfg
+++ b/config/hardening/hardened-centos.cfg
@@ -148,6 +148,7 @@ cp /tmp/classification-banner /mnt/sysimage/etc/classification-banner
 # Enable USB Guard
 yum localinstall -y /root/hardening/protobuf-*.rpm
 yum localinstall -y /root/hardening/usbguard-*.rpm
+usbguard generate-policy > /etc/usbguard/rules.conf
 systemctl enable usbguard.service
 
 # Disable Bluetooth Service


### PR DESCRIPTION
Hi Frank, awesome work on the CentOS hardening tools! USB Guard tends to give me a little grief on installation by disabling my mouse and keyboard. I made a slight modification to automatically generate the USB Guard rules file on installation such that it will allow USB devices that are connected during install. Please let me know if you would like to adopt this change and there is a smarter way of achieving this behavior. I'm happy to re-implement a better solution.