### PR TITLE
Better parsing of CENTOS_VERSION

### DIFF
--- a/createiso.sh
+++ b/createiso.sh
@@ -96,7 +96,7 @@ if [[ $? -eq 0 ]]; then
 	mkdir $DIR/hardened-tmp
 	$SUDO mount -o loop $1 $DIR/original-mnt
 	if [[ -e $DIR/original-mnt/.discinfo && -e $DIR/original-mnt/.treeinfo ]]; then
-		CENTOS_VERSION=$(grep "^7\.[0-9]" $DIR/original-mnt/.discinfo)
+		CENTOS_VERSION=$(grep -E "^7\.[0-9]+" $DIR/original-mnt/.discinfo)
 		MAJOR=$(echo $CENTOS_VERSION | awk -F '.' '{ print $1 }')
 		MINOR=$(echo $CENTOS_VERSION | awk -F '.' '{ print $2 }')
 		BUILD=$(ls $DIR/original-mnt/Packages/centos-release* | awk -F '.' '{ print $2 }')

--- a/createiso.sh
+++ b/createiso.sh
@@ -96,7 +96,7 @@ if [[ $? -eq 0 ]]; then
 	mkdir $DIR/hardened-tmp
 	$SUDO mount -o loop $1 $DIR/original-mnt
 	if [[ -e $DIR/original-mnt/.discinfo && -e $DIR/original-mnt/.treeinfo ]]; then
-		CENTOS_VERSION=$(grep "7\.[0-9]" $DIR/original-mnt/.discinfo)
+		CENTOS_VERSION=$(grep "^7\.[0-9]" $DIR/original-mnt/.discinfo)
 		MAJOR=$(echo $CENTOS_VERSION | awk -F '.' '{ print $1 }')
 		MINOR=$(echo $CENTOS_VERSION | awk -F '.' '{ print $2 }')
 		BUILD=$(ls $DIR/original-mnt/Packages/centos-release* | awk -F '.' '{ print $2 }')

--- a/createiso.sh
+++ b/createiso.sh
@@ -96,7 +96,7 @@ if [[ $? -eq 0 ]]; then
 	mkdir $DIR/hardened-tmp
 	$SUDO mount -o loop $1 $DIR/original-mnt
 	if [[ -e $DIR/original-mnt/.discinfo && -e $DIR/original-mnt/.treeinfo ]]; then
-		CENTOS_VERSION=$(grep "7." $DIR/original-mnt/.discinfo)
+		CENTOS_VERSION=$(grep "7\.[0-9]" $DIR/original-mnt/.discinfo)
 		MAJOR=$(echo $CENTOS_VERSION | awk -F '.' '{ print $1 }')
 		MINOR=$(echo $CENTOS_VERSION | awk -F '.' '{ print $2 }')
 		BUILD=$(ls $DIR/original-mnt/Packages/centos-release* | awk -F '.' '{ print $2 }')


### PR DESCRIPTION
Fixed regular expression so that CENTOS_VERSION is properly grepped from .discinfo.   Note, this was found attempting to build from latest Centos 7.5.


```
$ sudo ./createiso.sh CentOS-7-x86_64-DVD-1804.iso
Mounting CentOS DVD Image...
mount: /dev/loop0 is write-protected, mounting read-only
ERROR: Image is not CentOS 7.4+
```


Before:
```
$ grep "7." .discinfo
1525379451.112078
7.5
```

After:
```
$ grep "7\.[0-9]" .discinfo
7.5
```