### PR TITLE
If path to ISO contains '.' then script fails

### DIFF
--- a/createiso.sh
+++ b/createiso.sh
@@ -99,8 +99,8 @@ if [[ $? -eq 0 ]]; then
 		CENTOS_VERSION=$(grep -E "^7\.[0-9]+" $DIR/original-mnt/.discinfo)
 		MAJOR=$(echo $CENTOS_VERSION | awk -F '.' '{ print $1 }')
 		MINOR=$(echo $CENTOS_VERSION | awk -F '.' '{ print $2 }')
-		BUILD=$(ls $DIR/original-mnt/Packages/centos-release* | awk -F '.' '{ print $2 }')
-		ARCH=$(ls $DIR/original-mnt/Packages/centos-release* | awk -F '.' '{ print $5 }')
+		BUILD=$(cd $DIR/original-mnt/Packages/; ls centos-release* | awk -F '.' '{ print $2 }')
+		ARCH=$(cd $DIR/original-mnt/Packages/; ls centos-release* | awk -F '.' '{ print $5 }')
 		HARDENED_ISO="CentOS-$MAJOR.$MINOR-$ARCH-DVD-$BUILD-hardened.iso"
 		if [[ $MAJOR -ne 7 ]]; then
 			echo "ERROR: Image is not CentOS 7.4+"


### PR DESCRIPTION
If the path to the original ISO file contains a '.' (dot)(e.g. "/home/buchanan/isobuild.d/CentOS-7-x86_64-DVD-1804.iso"), the 'awk -F .' parsing of the MAJOR and MINOR release numbers inserts components of the path instead of just the intended numbers. This causes the output path of the genisoimage command to contain an invalid path. Added a subshell 'cd' to the directory before the 'ls' to prevent the error.